### PR TITLE
feat: benchmark for plasma/redis mixins

### DIFF
--- a/benchmark/shm.md
+++ b/benchmark/shm.md
@@ -1,0 +1,41 @@
+# Benchmark of shared memory mixins
+
+# Prerequisites
+redis-server should be installed and running.
+you can run redis-server with the following command:
+```bash
+sudo apt install redis-server
+```
+
+# Run
+
+`python ./shm.py`
+
+# Results
+
+
+The benchmark on my machine(AMD Ryzen 9 5900X) is as follows:
+
+plasma          size:         1 times: min(0.00024435)  mid(0.00027904) max(0.0016582)  95%(0.00025926) Std.(2.5355e-05)
+redis_unix      size:         1 times: min(0.0001597)   mid(0.00018997) max(0.00060593) 95%(0.00016197) Std.(2.8627e-05)
+redis_tcp       size:         1 times: min(0.00020048)  mid(0.00022785) max(0.0013715)  95%(0.00021585) Std.(3.0378e-05)
+plasma          size:      1024 times: min(0.00024969)  mid(0.00028456) max(0.00059021) 95%(0.00027068) Std.(2.4854e-05)
+redis_unix      size:      1024 times: min(0.00017412)  mid(0.00020382) max(0.00056432) 95%(0.00018177) Std.(2.6104e-05)
+redis_tcp       size:      1024 times: min(0.00020199)  mid(0.00023232) max(0.00047119) 95%(0.00021916) Std.(2.5673e-05)
+plasma          size:     65536 times: min(0.00065814)  mid(0.00070226) max(0.0019353)  95%(0.00066868) Std.(5.567e-05)
+redis_unix      size:     65536 times: min(0.00089813)  mid(0.0009925)  max(0.0014891)  95%(0.00091763) Std.(6.3486e-05)
+redis_tcp       size:     65536 times: min(0.0011009)   mid(0.0011716)  max(0.0016486)  95%(0.0011106)  Std.(7.29e-05)
+plasma          size:   3145728 times: min(0.028673)    mid(0.029416)   max(0.037621)   95%(0.028706)   Std.(0.0021678)
+redis_unix      size:   3145728 times: min(0.046763)    mid(0.04841)    max(0.055645)   95%(0.046845)   Std.(0.0020143)
+redis_tcp       size:   3145728 times: min(0.040182)    mid(0.051077)   max(0.059047)   95%(0.040738)   Std.(0.0035537)
+>>> benchmark for normal data mixed with numpy array
+========================================================================================================================
+plasma          size: <unknown> times: min(0.00025614)  mid(0.00029197) max(0.0025628)  95%(0.00027462) Std.(4.3949e-05)
+redis_unix      size: <unknown> times: min(0.00018343)  mid(0.00021754) max(0.00064727) 95%(0.00019482) Std.(3.6763e-05)
+redis_tcp       size: <unknown> times: min(0.00020191)  mid(0.00025083) max(0.00062813) 95%(0.0002194)  Std.(4.2144e-05)
+========================================================================================================================
+plasma          size: <unknown> times: min(0.0005683)   mid(0.0006267)  max(0.0010101)  95%(0.00057886) Std.(5.818e-05)
+redis_unix      size: <unknown> times: min(0.00064607)  mid(0.00071034) max(0.0012368)  95%(0.00065222) Std.(7.1132e-05)
+redis_tcp       size: <unknown> times: min(0.00060924)  mid(0.00071632) max(0.0011938)  95%(0.00061993) Std.(8.9151e-05)
+
+The table above shows how the data size affects the performance rank of different methods. Redis_unix performs better than redis_tcp and plasma when the data size is small, but plasma outperforms redis when the data size is large.

--- a/tests/shm.py
+++ b/tests/shm.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+from functools import partial
+
+import gc
+import subprocess
+import traceback
+from dataclasses import dataclass
+from time import perf_counter
+from typing import Any
+from mosec import Worker
+import numpy as np
+
+from pyarrow import plasma
+
+from mosec.mixin import PlasmaShmIPCMixin,RedisShmIPCMixin
+
+
+unix_path = "/tmp/redis/redis.sock"
+tcp_path = "127.0.0.1:6379"
+
+@dataclass(frozen=True)
+class Data:
+    arr: np.ndarray | dict
+    msg: str
+    epoch: int
+
+class PlasmaForwardWorker(PlasmaShmIPCMixin):
+    def forward(self, data: Data) -> Any:
+        return data
+    
+class RedisForwardWorker(RedisShmIPCMixin):
+    def forward(self, data: Data) -> Any:
+        return data
+
+def generate_data():
+    return (
+        Data(
+            {"msg": "long message" * 1000, "vec": np.random.rand(1024)},
+            "long message with 1024 vector",
+            10000,
+        ),
+        Data(
+            {
+                "int": 233,
+                "float": 3.14,
+                "vec": np.random.rand(1024),
+                "matrix": np.random.rand(64, 1024),
+            },
+            "int, float, vector and matrix",
+            100,
+        ),
+    )
+
+
+def generate_np_data():
+    return (
+        Data(np.random.rand(1), "scalar", 10000),
+        Data(np.random.rand(1024), "vector", 10000),
+        Data(np.random.rand(64, 1024), "matrix", 1000),
+        Data(np.random.rand(3, 1024, 1024), "image", 100),
+    )
+
+def test_shm_worker(worker:Worker,data: Data):
+    _id=worker.serialize_ipc(data.arr)
+    worker.deserialize_ipc(_id)
+
+def time_record(func, data: Data, threshold=1):
+    res = []
+    total_sec = 0
+    while total_sec < threshold:
+        for _ in range(data.epoch):
+            t0 = perf_counter()
+            try:
+                func(data)
+            except:
+                print(traceback.format_exc())
+            finally:
+                res.append(perf_counter() - t0)
+                total_sec += res[-1]
+    return res
+
+
+def display_result(func, data):
+    gc_flag = gc.isenabled()
+    gc.disable()
+    try:
+        t = time_record(func, data)
+    finally:
+        if gc_flag:
+            gc.enable()
+    size = data.arr.size if isinstance(data.arr, np.ndarray) else "<unknown>"
+    print(
+        f"{func.__name__}\tsize: {size:9}\ttimes: "
+        f"min({np.min(t):.5})\tmid({np.median(t):.5})\tmax({np.max(t):.5})\t"
+        f"95%({np.percentile(t, 0.95):.5})\tStd.({np.std(t):.5})",
+    )
+
+def init_redis_shm_worker(url):
+    RedisShmIPCMixin.set_redis_url(url)
+    worker=RedisForwardWorker()
+    worker._get_client()
+    return worker
+
+def benchmark():
+
+    with plasma.start_plasma_store(plasma_store_memory=10 * 1000 * 1000 * 1000) as ( 
+        shm_path,
+        plasma_proc,
+    ), subprocess.Popen(["redis-server","--unixsocket",unix_path]) as redis_proc:
+        global plasma_worker,redis_unix_worker,redis_tcp_worker
+        PlasmaForwardWorker.set_plasma_path(shm_path)
+        plasma_worker=PlasmaForwardWorker()
+        redis_unix_worker=init_redis_shm_worker(f"unix://{unix_path}")
+        redis_tcp_worker=init_redis_shm_worker(f"redis://@{tcp_path}")
+        
+        name_worker={
+            "plasma\t":plasma_worker,
+            "redis_unix":redis_unix_worker,
+            "redis_tcp":redis_tcp_worker
+        }
+        funcs=[]
+        for name,worker in name_worker.items():
+            f=partial(test_shm_worker,worker)
+            setattr(f,"__name__",name)
+            funcs.append(f)
+
+        print(">>> benchmark for numpy array")
+        
+        for data in generate_np_data():
+            for func in funcs:
+                display_result(func, data)
+
+        print(">>> benchmark for normal data mixed with numpy array")
+        for data in generate_data():
+            print("=" * 120)
+            for func in funcs:
+                display_result(func, data)
+        plasma_proc.kill()
+        redis_proc.kill()
+
+if __name__ == "__main__":
+    benchmark()


### PR DESCRIPTION
# Description
Make a benchmark for plasma/redis mixins.

# Conclusion
Redis_unix performs better than redis_tcp and plasma when the data size is small, but plasma outperforms redis when the data size is large.